### PR TITLE
Fixed no flag resulting in no to language error

### DIFF
--- a/cmd/capstone/client/main.go
+++ b/cmd/capstone/client/main.go
@@ -26,6 +26,11 @@ func main() {
 	toFlag := flag.String("to", "", "language to translate to")
 	flag.Parse()
 
+	if *fFlag == "" && *fromFlag == "" && !*hFlag && !*helpFlag && *tFlag == "" && *toFlag == "" {
+		flag.Usage()
+		return
+	}
+
 	if *hFlag || *helpFlag {
 		flag.Usage()
 		return


### PR DESCRIPTION
Added if statement to fix the Capstone Client from printing out the no to language error if no flags were included in the call